### PR TITLE
Fix missing namespace

### DIFF
--- a/llvm/lib/Analysis/MLUnrollAdvisor.cpp
+++ b/llvm/lib/Analysis/MLUnrollAdvisor.cpp
@@ -185,7 +185,7 @@ MLUnrollAdvisor::getAdviceImpl(UnrollAdviceInfo UAI) {
 
 #else // defined(LLVM_HAVE_TFLITE)
 
-std::unique_ptr<UnrollAdvisor>
+std::unique_ptr<llvm::UnrollAdvisor>
 llvm::getReleaseModeUnrollAdvisor(LLVMContext &Ctx) {
   llvm_unreachable("Requires LLVM to be compiled with TFLite.");
 }


### PR DESCRIPTION
Without this change, I get this exception:
```
/Users/me/llvm-project/llvm/lib/Analysis/MLUnrollAdvisor.cpp:188:17: error: unknown type name 'UnrollAdvisor'; did you mean 'llvm::UnrollAdvisor'?
  188 | std::unique_ptr<UnrollAdvisor>
      |                 ^~~~~~~~~~~~~
      |                 llvm::UnrollAdvisor
/Users/me/llvm-project/llvm/include/llvm/Analysis/UnrollAdvisor.h:109:7: note: 'llvm::UnrollAdvisor' declared here
  109 | class UnrollAdvisor {
      |       ^
1 error generated.
make[2]: *** [lib/Analysis/CMakeFiles/LLVMAnalysis.dir/MLUnrollAdvisor.cpp.o] Error 1
```

System:
```
OS: macOS Sequoia 15.5 arm64
Kernel: Darwin 24.5.0
CPU: Apple M2 Pro (10) @ 3.50 GHz
```