### PR TITLE
Don't use `llvm::Module::dump` if not in debug mode

### DIFF
--- a/llvm/lib/Transforms/IPO/InputGen.cpp
+++ b/llvm/lib/Transforms/IPO/InputGen.cpp
@@ -1379,9 +1379,11 @@ InputGenInstrumentEntriesPass::run(Module &M, AnalysisManager<Module> &MAM) {
   if (!Changed)
     return PreservedAnalyses::all();
 
+#ifndef NDEBUG
   if (verifyModule(M))
     M.dump();
   assert(!verifyModule(M, &errs()));
+#endif
 
   return PreservedAnalyses::none();
 }
@@ -1395,9 +1397,11 @@ InputGenInstrumentMemoryPass::run(Module &M, AnalysisManager<Module> &MAM) {
   if (!Changed)
     return PreservedAnalyses::all();
 
+#ifndef NDEBUG
   if (verifyModule(M))
     M.dump();
   assert(!verifyModule(M, &errs()));
+#endif
 
   return PreservedAnalyses::none();
 }

--- a/llvm/lib/Transforms/IPO/Instrumentor.cpp
+++ b/llvm/lib/Transforms/IPO/Instrumentor.cpp
@@ -1125,9 +1125,11 @@ PreservedAnalyses InstrumentorPass::run(Module &M, ModuleAnalysisManager &MAM) {
   if (!Changed)
     return PreservedAnalyses::all();
 
+#ifndef NDEBUG
   if (verifyModule(M))
     M.dump();
   assert(!verifyModule(M, &errs()));
+#endif
 
   return PreservedAnalyses::none();
 }
@@ -1216,7 +1218,9 @@ InstrumentationConfig::getBasePointerInfo(Value &V,
       IIRB.IRB.SetInsertPointPastAllocas(
           IIRB.IRB.GetInsertBlock()->getParent());
     else {
+#ifndef NDEBUG
       VPtr->dump();
+#endif
       llvm_unreachable("Unexpected base pointer!");
     }
     ensureDbgLoc(IIRB.IRB);

--- a/llvm/lib/Transforms/IPO/LightSan.cpp
+++ b/llvm/lib/Transforms/IPO/LightSan.cpp
@@ -261,7 +261,9 @@ public:
           CB->setArgOperand(ACI->SizeRHSArgNo, Mul);
         }
       } else {
+#ifndef NDEBUG
         Obj->dump();
+#endif
         llvm_unreachable("TODO");
       }
     }
@@ -532,11 +534,13 @@ struct LightSanInstrumentationConfig : public InstrumentationConfig {
 
     for (auto [I, OpNo] : ReplStack) {
       auto *NewOp = V2M.lookup({I->getOperand(OpNo), Fn});
+#ifndef NDEBUG
       if (!NewOp) {
         I->dump();
         I->getOperand(OpNo)->dump();
       }
       assert(NewOp);
+#endif
       I->setOperand(OpNo, NewOp);
     }
 
@@ -547,9 +551,11 @@ struct LightSanInstrumentationConfig : public InstrumentationConfig {
       IIRB.hoistInstructionsAndAdjustIP(*I, BestIP, DT);
 
     auto *MPtr = V2M.lookup({&VPtr, Fn});
+#ifndef NDEBUG
     if (!MPtr)
       VPtr.dump();
     assert(MPtr);
+#endif
     return MPtr;
   }
 
@@ -3312,10 +3318,11 @@ PreservedAnalyses run(Module &M, AnalysisManager<Module> &MAM) {
   for (auto *Fn : DeadFns)
     Fn->eraseFromParent();
 
+#ifndef NDEBUG
   if (verifyModule(M))
     M.dump();
-
   assert(!verifyModule(M, &errs()));
+#endif
 
 #if 1
   ModulePassManager MPM;


### PR DESCRIPTION
This fixes build errors like
```
[ 98%] Building CXX object tools/dsymutil/CMakeFiles/dsymutil.dir/BinaryHolder.cpp.o
Undefined symbols for architecture arm64:
  "llvm::Value::dump() const", referenced from:
      llvm::instrumentor::InstrumentationConfig::getBasePointerInfo(llvm::Value&, llvm::instrumentor::InstrumentorIRBuilderTy&) in libLLVMipo.a[30](Instrumentor.cpp.o)
      (anonymous namespace)::LightSanInstrumentationConfig::getMPtr(llvm::Value&, llvm::instrumentor::InstrumentorIRBuilderTy&) in libLLVMipo.a[32](LightSan.cpp.o)
      (anonymous namespace)::LightSanInstrumentationConfig::getMPtr(llvm::Value&, llvm::instrumentor::InstrumentorIRBuilderTy&) in libLLVMipo.a[32](LightSan.cpp.o)
      (anonymous namespace)::LightSanInstrumentationConfig::getMPtr(llvm::Value&, llvm::instrumentor::InstrumentorIRBuilderTy&) in libLLVMipo.a[32](LightSan.cpp.o)
      (anonymous namespace)::LightSanInstrumentationConfig::getMPtr(llvm::Value&, llvm::instrumentor::InstrumentorIRBuilderTy&) in libLLVMipo.a[32](LightSan.cpp.o)
      (anonymous namespace)::AttributorInfoCache::insertRegisterCall(llvm::Value*, llvm::CallInst*, llvm::instrumentor::InstrumentorIRBuilderTy&) in libLLVMipo.a[32](LightSan.cpp.o)
  "llvm::Module::dump() const", referenced from:
      llvm::InputGenInstrumentEntriesPass::run(llvm::Module&, llvm::AnalysisManager<llvm::Module>&) in libLLVMipo.a[29](InputGen.cpp.o)
      llvm::InputGenInstrumentMemoryPass::run(llvm::Module&, llvm::AnalysisManager<llvm::Module>&) in libLLVMipo.a[29](InputGen.cpp.o)
      llvm::InstrumentorPass::run(llvm::Module&, llvm::AnalysisManager<llvm::Module>&) in libLLVMipo.a[30](Instrumentor.cpp.o)
      (anonymous namespace)::run(llvm::Module&, llvm::AnalysisManager<llvm::Module>&) in libLLVMipo.a[32](LightSan.cpp.o)
ld: symbol(s) not found for architecture arm64
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [lib/libLTO.dylib] Error 1
make[1]: *** [tools/lto/CMakeFiles/LTO.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[ 98%] Building CXX object tools/llvm-libtool-darwin/CMakeFiles/llvm-libtool-darwin.dir/llvm-libtool-darwin.cpp.o
[ 98%] Building CXX object tools/bugpoint/CMakeFiles/bugpoint.dir/ExtractFunction.cpp.o
[ 98%] Linking CXX executable ../../bin/llvm-lto
Undefined symbols for architecture arm64:
  "llvm::Value::dump() const", referenced from:
      llvm::instrumentor::InstrumentationConfig::getBasePointerInfo(llvm::Value&, llvm::instrumentor::InstrumentorIRBuilderTy&) in libLLVMipo.a[30](Instrumentor.cpp.o)
      (anonymous namespace)::LightSanInstrumentationConfig::getMPtr(llvm::Value&, llvm::instrumentor::InstrumentorIRBuilderTy&) in libLLVMipo.a[32](LightSan.cpp.o)
      (anonymous namespace)::LightSanInstrumentationConfig::getMPtr(llvm::Value&, llvm::instrumentor::InstrumentorIRBuilderTy&) in libLLVMipo.a[32](LightSan.cpp.o)
      (anonymous namespace)::LightSanInstrumentationConfig::getMPtr(llvm::Value&, llvm::instrumentor::InstrumentorIRBuilderTy&) in libLLVMipo.a[32](LightSan.cpp.o)
      (anonymous namespace)::LightSanInstrumentationConfig::getMPtr(llvm::Value&, llvm::instrumentor::InstrumentorIRBuilderTy&) in libLLVMipo.a[32](LightSan.cpp.o)
      (anonymous namespace)::AttributorInfoCache::insertRegisterCall(llvm::Value*, llvm::CallInst*, llvm::instrumentor::InstrumentorIRBuilderTy&) in libLLVMipo.a[32](LightSan.cpp.o)
  "llvm::Module::dump() const", referenced from:
      llvm::InputGenInstrumentEntriesPass::run(llvm::Module&, llvm::AnalysisManager<llvm::Module>&) in libLLVMipo.a[29](InputGen.cpp.o)
      llvm::InputGenInstrumentMemoryPass::run(llvm::Module&, llvm::AnalysisManager<llvm::Module>&) in libLLVMipo.a[29](InputGen.cpp.o)
      llvm::InstrumentorPass::run(llvm::Module&, llvm::AnalysisManager<llvm::Module>&) in libLLVMipo.a[30](Instrumentor.cpp.o)
      (anonymous namespace)::run(llvm::Module&, llvm::AnalysisManager<llvm::Module>&) in libLLVMipo.a[32](LightSan.cpp.o)
ld: symbol(s) not found for architecture arm64
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [bin/llvm-lto] Error 1
make[1]: *** [tools/llvm-lto/CMakeFiles/llvm-lto.dir/all] Error 2
[ 98%] Building CXX object tools/dsymutil/CMakeFiles/dsymutil.dir/CFBundle.cpp.o
```
    
Used build commands:
```
cmake ../llvm -DLLVM_ENABLE_PROJECTS="clang;lld" -DLLVM_ENABLE_RUNTIMES="compiler-rt" -DCOMPILER_RT_BUILD_INPUTGEN="ON" -DCMAKE_BUILD_TYPE=Release
make -j10
```
   
System:
```
OS: macOS Sequoia 15.5 arm64
Kernel: Darwin 24.5.0
CPU: Apple M2 Pro (10) @ 3.50 GHz
```