### PR TITLE
Include span

### DIFF
--- a/compiler-rt/lib/inputgen/generate.cpp
+++ b/compiler-rt/lib/inputgen/generate.cpp
@@ -13,6 +13,7 @@
 #include <string>
 #include <string_view>
 #include <thread>
+#include <span>
 
 // We are depending on this = false to be embedded as an initial value in the
 // global of the binary so that we have it set to false before we get the call


### PR DESCRIPTION
Worked on my M2 Pro before, but not on several Linux systems:
```
/tmp/input-gen_llvm-project/compiler-rt/lib/inputgen/generate.cpp:36:41: error: no template named 'span' in namespace 'std'
   36 |   SharedState(uint32_t NumThreads, std::span<uint32_t> Seeds)
      |                                    ~~~~~^
/tmp/input-gen_llvm-project/compiler-rt/lib/inputgen/generate.cpp:57:8: error: no template named 'span' in namespace 'std'
   57 |   std::span<uint32_t> Seeds;
      |   ~~~~~^
/tmp/input-gen_llvm-project/compiler-rt/lib/inputgen/generate.cpp:44:5: warning: 'std::unique_lock' may not intend to support class template argument deduction [-Wctad-maybe-unsupported]
   44 |     std::unique_lock Lock(Mutex);
      |     ^
/opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/unique_lock.h:57:11: note: add a deduction guide to suppress this warning
   57 |     class unique_lock
      |           ^
/tmp/input-gen_llvm-project/compiler-rt/lib/inputgen/generate.cpp:164:8: error: no member named 'span' in namespace 'std'
  164 |   std::span<uint32_t> SeedsSpan{Seeds.data() - FirstInput,
      |        ^~~~
/tmp/input-gen_llvm-project/compiler-rt/lib/inputgen/generate.cpp:164:13: error: unexpected type name 'uint32_t': expected expression
  164 |   std::span<uint32_t> SeedsSpan{Seeds.data() - FirstInput,
      |             ^
/tmp/input-gen_llvm-project/compiler-rt/lib/inputgen/generate.cpp:164:23: error: use of undeclared identifier 'SeedsSpan'
  164 |   std::span<uint32_t> SeedsSpan{Seeds.data() - FirstInput,
      |                       ^~~~~~~~~
/tmp/input-gen_llvm-project/compiler-rt/lib/inputgen/generate.cpp:167:30: error: use of undeclared identifier 'SeedsSpan'
  167 |   SharedState SS(NumThreads, SeedsSpan);
      |                              ^~~~~~~~~
```

(Successor of https://github.com/input-gen/llvm-project/pull/3)